### PR TITLE
Add an options parameter to account for extras parameters

### DIFF
--- a/lib/dyn/messaging/bounces.rb
+++ b/lib/dyn/messaging/bounces.rb
@@ -6,9 +6,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,20 +23,20 @@ module Dyn
         @dyn = dyn
       end
 
-      def count(starttime, endtime)
-        @dyn.get("#{resource_path}/count", {starttime:starttime, endtime:endtime})
+      def count(starttime, endtime, options={})
+        @dyn.get("#{resource_path}/count", {starttime:starttime, endtime:endtime}.merge(options))
       end
 
-      def list(starttime, endtime, startindex=0, emailaddress=nil)
+      def list(starttime, endtime, startindex=0, emailaddress=nil, options={})
         if not emailaddress.nil?
-          @dyn.get("#{resource_path}", {starttime:starttime, endtime:endtime, startindex:startindex, emailaddress:emailaddress})
+          @dyn.get("#{resource_path}", {starttime:starttime, endtime:endtime, startindex:startindex, emailaddress:emailaddress}.merge(options))
         else
-          @dyn.get("#{resource_path}", {starttime:starttime, endtime:endtime, startindex:startindex})
+          @dyn.get("#{resource_path}", {starttime:starttime, endtime:endtime, startindex:startindex}.merge(options))
         end
       end
-      
+
       private
-      
+
       def resource_path
         "reports/bounces"
       end

--- a/spec/messaging/bounces_spec.rb
+++ b/spec/messaging/bounces_spec.rb
@@ -7,6 +7,15 @@ describe Dyn::Messaging::Client do
     subject { @dyn.bounces }
     it_should_behave_like "a collection", "reports/bounces"
 
+    it "should count" do
+      start_time = 1
+      end_time = 2
+
+      stub = stub_request(:get, "#{@API_BASE_PATH}/reports/bounces/count?apikey=#{@DEFAULT_API_KEY}&starttime=#{start_time}&endtime=#{end_time}")
+      subject.send(:count, start_time, end_time)
+      expect(stub).to have_been_requested
+    end
+
     it "should list results for a specific receiver email address" do
       start_time = 1
       end_time = 2
@@ -15,6 +24,18 @@ describe Dyn::Messaging::Client do
 
       stub = stub_request(:get, "#{@API_BASE_PATH}/reports/bounces?apikey=#{@DEFAULT_API_KEY}&starttime=#{start_time}&endtime=#{end_time}&startindex=#{start_index}&emailaddress=#{email_address}")
       subject.send(:list, start_time, end_time, start_index, email_address)
+      expect(stub).to have_been_requested
+    end
+
+    it "should list results for a specific bounce type" do
+      start_time = 1
+      end_time = 2
+      start_index = 40
+      email_address = "abc@domain.com"
+      bounce_type = "hard"
+
+      stub = stub_request(:get, "#{@API_BASE_PATH}/reports/bounces?apikey=#{@DEFAULT_API_KEY}&starttime=#{start_time}&endtime=#{end_time}&startindex=#{start_index}&emailaddress=#{email_address}&bouncetype=#{bounce_type}")
+      subject.send(:list, start_time, end_time, start_index, email_address, {bouncetype: bounce_type})
       expect(stub).to have_been_requested
     end
 


### PR DESCRIPTION
Add an options parameter to account for extras parameters for the reports/bounces api endpoints

Signed-off-by: Salimane Adjao Moustapha me@salimane.com
